### PR TITLE
Feature queue auto restart

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "bardic-inspiration",
   "title": "Bardic Inspiration",
   "description": "Synchronized YouTube DJ for Foundry VTT - Play YouTube videos in sync across all players",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "compatibility": {
     "minimum": "12",
     "verified": "13.347"
@@ -44,9 +44,9 @@
       }
     ]
   },
-  "url": "https://github.com/journeyjt/BardicInspiration",
-  "manifest": "https://github.com/journeyjt/BardicInspiration/releases/latest/download/module.json",
-  "download": "https://github.com/journeyjt/BardicInspiration/releases/latest/download/module.zip",
+  "url": "http://host.docker.internal:5000/modules/bardic-inspiration",
+  "manifest": "http://host.docker.internal:5000/modules/bardic-inspiration/module.json",
+  "download": "http://host.docker.internal:5000/modules/bardic-inspiration/module.zip",
   "license": "LICENSE",
   "readme": "README.md",
   "bugs": "https://github.com/journeyjt/BardicInspiration/issues",

--- a/module.json
+++ b/module.json
@@ -44,9 +44,9 @@
       }
     ]
   },
-  "url": "http://host.docker.internal:5000/modules/bardic-inspiration",
-  "manifest": "http://host.docker.internal:5000/modules/bardic-inspiration/module.json",
-  "download": "http://host.docker.internal:5000/modules/bardic-inspiration/module.zip",
+  "url": "https://github.com/journeyjt/BardicInspiration",
+  "manifest": "https://github.com/journeyjt/BardicInspiration/releases/latest/download/module.json",
+  "download": "https://github.com/journeyjt/BardicInspiration/releases/latest/download/module.zip",
   "license": "LICENSE",
   "readme": "README.md",
   "bugs": "https://github.com/journeyjt/BardicInspiration/issues",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bardic-inspiration",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bardic-inspiration",
-      "version": "0.8.34",
+      "version": "0.8.35",
       "license": "MIT",
       "devDependencies": {
         "@league-of-foundry-developers/foundry-vtt-types": "^13.340.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bardic-inspiration",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "description": "A Foundry VTT module",
   "type": "module",
   "scripts": {

--- a/src/apps/YouTubeDJApp.ts
+++ b/src/apps/YouTubeDJApp.ts
@@ -906,15 +906,9 @@ export class YouTubeDJApp extends foundry.applications.api.HandlebarsApplication
       return;
     }
     
-    // Check if there's a next video in the queue
-    const nextIndex = this.queueState.currentIndex + 1;
-    if (nextIndex < this.queueState.items.length) {
-      logger.debug('🎵 YouTube DJ | Auto-advancing to next video in queue');
-      this._playNextInQueue();
-    } else {
-      logger.debug('🎵 YouTube DJ | Reached end of queue, no auto-advance');
-      ui.notifications?.info('Queue finished - add more videos or manually restart');
-    }
+    // Always auto-advance - _playNextInQueue handles queue restart logic
+    logger.debug('🎵 YouTube DJ | Auto-advancing to next video in queue');
+    this._playNextInQueue();
   }
 
   /**


### PR DESCRIPTION
  Fix queue auto-restart regression after video ends

  - Simplify _autoAdvanceQueue to always call _playNextInQueue
  - Remove redundant end-of-queue check that prevented auto-restart
  - Queue now properly loops back to beginning when last video finishes
  - Single video queues will now repeat continuously as expected
  - Maintains existing queue restart logic in _playNextInQueue method

  Resolves issue where queue would stop instead of restarting after
  the final video completed playback.