### PR TITLE
"Fix GitHub Actions permissions for release updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+  
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
  - Add 'contents: write' permission to workflow
  - Fixes 403 error when updating releases with assets